### PR TITLE
kernel: Use TXPSR enum instead of magic values

### DIFF
--- a/kernel/dw1000.c
+++ b/kernel/dw1000.c
@@ -691,7 +691,7 @@ static const struct dw1000_prf_config dw1000_prf_configs[] = {
 static const struct dw1000_rate_config dw1000_rate_configs[] = {
 	[DW1000_RATE_110K] = {
 		.tdsym_ns = 8205,
-		.txpsr = 0x3,
+		.txpsr = DW1000_TXPSR_4096,
 		.drx_tune0b = 0x000a,
 		.drx_tune1b = 0x0064,
 		.drx_tune2 = {
@@ -702,7 +702,7 @@ static const struct dw1000_rate_config dw1000_rate_configs[] = {
 	},
 	[DW1000_RATE_850K] = {
 		.tdsym_ns = 1025,
-		.txpsr = 0x2,
+		.txpsr = DW1000_TXPSR_1024,
 		.drx_tune0b = 0x0001,
 		.drx_tune1b = 0x0020,
 		.drx_tune2 = {
@@ -713,7 +713,7 @@ static const struct dw1000_rate_config dw1000_rate_configs[] = {
 	},
 	[DW1000_RATE_6800K] = {
 		.tdsym_ns = 128,
-		.txpsr = 0x1,
+		.txpsr = DW1000_TXPSR_64,
 		.drx_tune0b = 0x0001,
 		.drx_tune1b = 0x0010,
 		.drx_tune2 = {
@@ -829,8 +829,7 @@ static int dw1000_reconfigure(struct dw1000 *dw, unsigned int changed)
 	}
 	if (changed & (DW1000_CONFIGURE_PRF | DW1000_CONFIGURE_RATE)) {
 		mask = (DW1000_TX_FCTRL2_TXPRF_MASK |
-			DW1000_TX_FCTRL2_TXPSR_MASK |
-			DW1000_TX_FCTRL2_PE_MASK);
+			DW1000_TX_FCTRL2_TXPSR_MASK);
 		value = (DW1000_TX_FCTRL2_TXPRF(prf) |
 			 DW1000_TX_FCTRL2_TXPSR(rate_cfg->txpsr));
 		if ((rc = regmap_update_bits(dw->tx_fctrl.regs,
@@ -2662,7 +2661,6 @@ static int dw1000_init(struct dw1000 *dw)
 	if ((rc = regmap_update_bits(dw->pmsc.regs, DW1000_PMSC_CTRL0,
 				     mask, value)) != 0)
 		return rc;
-
 	/* Configure GPIOs as LED outputs */
 	mask = (DW1000_GPIO_MODE_MSGP0_MASK | DW1000_GPIO_MODE_MSGP1_MASK |
 		DW1000_GPIO_MODE_MSGP2_MASK | DW1000_GPIO_MODE_MSGP3_MASK);

--- a/kernel/dw1000.h
+++ b/kernel/dw1000.h
@@ -232,8 +232,7 @@ union dw1000_ldotune {
 #define DW1000_TX_FCTRL2_TXPRF(n)		((n) << 0)
 #define DW1000_TX_FCTRL2_TXPRF_MASK		DW1000_TX_FCTRL2_TXPRF(0x3)
 #define DW1000_TX_FCTRL2_TXPSR(n)		((n) << 2)
-#define DW1000_TX_FCTRL2_TXPSR_MASK		DW1000_TX_FCTRL2_TXPSR(0x3)
-#define DW1000_TX_FCTRL2_PE_MASK		0x30
+#define DW1000_TX_FCTRL2_TXPSR_MASK		DW1000_TX_FCTRL2_TXPSR(0xF)
 #define DW1000_TX_FCTRL4		0x04
 #define DW1000_TX_FCTRL4_IFSDELAY(n)		(((n) - 6) << 0)
 #define DW1000_TX_FCTRL4_IFSDELAY_MASK		DW1000_TX_FCTRL4_IFSDELAY(0xff)
@@ -493,6 +492,17 @@ union dw1000_ldotune {
  * protection against inaccurate receive timestamps.
  */
 #define DW1000_LQI_THRESHOLD_DEFAULT 16
+
+/* TX Preamble lenghts */
+enum dw1000_txpsr {
+	DW1000_TXPSR_64   = 0x1,
+	DW1000_TXPSR_128  = 0x5,
+	DW1000_TXPSR_256  = 0x9,
+	DW1000_TXPSR_512  = 0xD,
+	DW1000_TXPSR_1024 = 0x2,
+	DW1000_TXPSR_2048 = 0xA,
+	DW1000_TXPSR_4096 = 0x3,
+};
 
 /* Pulse repetition frequencies */
 enum dw1000_prf {


### PR DESCRIPTION
The TXPSR and PE and four consecutive bits in TX_FCTRL register.
Include all of them in DW1000_TX_FCTRL2_TXPSR_ macros.